### PR TITLE
Fix support for leading zeros in source numbers

### DIFF
--- a/gleam/__init__.py
+++ b/gleam/__init__.py
@@ -133,7 +133,7 @@ def pipeline(path, spectra, config, plot, inspect, verbose, bin, nproc):
     # sources is trivially parallelizable
     nproc = 1 if inspect else nproc
     with Pool(nproc) as p:
-        p.starmap(main.run_main, unique_sources)
+        p.starmap(gleam.main.run_main, unique_sources)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
As per the example, source numbers should allow for leading zeros both
in the spectrum file name as well as in the spectrum overrides. The dot
separated source identifier in the spectrum overrides is parsed as a
string, which is inflexible with respect to leading zeros.

Parse the source number as an integer in the spectrum overrides.