### PR TITLE
Strip line names in order to ignore white spaces

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ __pycache__
 .mypy_cache
 gleam.egg-info/
 *tar.gz
+.venv/

--- a/gleam/constants.py
+++ b/gleam/constants.py
@@ -200,9 +200,8 @@ class Config:
         if self.lines == "all":
             return table
         else:
-            mask = functools.reduce(
-                operator.or_, (table["line"] == line for line in self.lines)
-            )
+            lines = {line.strip() for line in self.lines}
+            mask = [line.strip() in lines for line in table["line"]]
             return table[mask]
 
     @property

--- a/gleam/plot_gaussian.py
+++ b/gleam/plot_gaussian.py
@@ -148,7 +148,7 @@ def plot_spectrum(
     title = (
         f"{target['Sample']}\t"
         + target["Pointing"].replace("_", "\_")
-        + f"\t{target['SourceNumber']}\tz={target['Redshift']:.3}"
+        + f"\t{target['SourceNumber']}\tz={float(target['Redshift']):.3}"
     )
 
     # Set the basename name of the png outfile
@@ -267,7 +267,7 @@ def overview_plot(
     title = (
         f"{target['Sample']}\t"
         + target["Pointing"].replace("_", "\_")
-        + f"\t{target['SourceNumber']}\tz={target['Redshift']:.3}"
+        + f"\t{target['SourceNumber']}\tz={float(target['Redshift']):.3}"
     )
     # Basename that will be used in the savefile name
     basename = rf.naming_convention(


### PR DESCRIPTION
Strip white spaces from the line names when matching the lines names specified in gleamconfig to those read from the line_list table.