### PR TITLE
Update latex import to fix deprecation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,5 @@ __pycache__
 .mypy_cache
 gleam.egg-info/
 *tar.gz
-.venv/
+.venv*
 dist/

--- a/gleam/matplotlibparams.py
+++ b/gleam/matplotlibparams.py
@@ -9,14 +9,11 @@ Some reasonable plotting parameters. Feel free to change as per your taste.
 """
 
 plt.rc("text", usetex=True)
-plt.rcParams["text.latex.preamble"] = [
-    r"\usepackage{amsmath}",
-    r"\usepackage[mode=text,per-mode=symbol]{siunitx}",  # i need upright \micro symbols, but you need...
-    r"\sisetup{detect-all}",  # ...this to force siunitx to actually use your fonts
-    r"\usepackage{helvet}",  # set the normal font here
-    r"\usepackage{sansmath}",  # load up the sansmath so that math -> helvet
-    r"\sansmath",  # <- tricky! -- gotta actually tell tex to use!'
-]
+plt.rc(
+    "text.latex",
+    preamble=r"\usepackage{amsmath} \usepackage{amsmath} \usepackage[mode=text,per-mode=symbol]{siunitx} \sisetup{detect-all} \usepackage{helvet} \usepackage{textgreek} \usepackage{sansmath} \sansmath",
+)
+
 
 ###########################################################################
 #                                                                         #


### PR DESCRIPTION
The way Latex packages are imported changed as of Matplotlib 3.5. Here is the [deprecation warning](https://matplotlib.org/3.3.0/api/prev_api_changes/api_changes_3.3.0/deprecations.html#setting-rcparams-text-latex-preamble-default-or-rcparams-pdf-preamble-to-non-strings) in Matplotlib 3.3.