### PR TITLE
Ensure positive EW error

### DIFF
--- a/gleam/gaussian_fitting.py
+++ b/gleam/gaussian_fitting.py
@@ -77,7 +77,7 @@ class Line:
     def ew_rest(self):
         # Equivalent width of the emission line in the restframe
         v = self.amplitude.value / self.continuum.value
-        e = v * np.sqrt(
+        e = np.abs(v) * np.sqrt(
             (self.continuum.error / self.continuum.value) ** 2
             + (self.amplitude.error / self.amplitude.value) ** 2
         )


### PR DESCRIPTION
Correct formula for the error on the EW, to ensure it is always positive, even when EW itself is negative.