### PR TITLE
Correct the flux density (lambda) when restframing

### DIFF
--- a/gleam/gaussian_fitting.py
+++ b/gleam/gaussian_fitting.py
@@ -942,8 +942,8 @@ def do_gaussian(
     spectrum_fit = model_selection(
         target["Redshift"],
         spectrum_line["wl_rest"],
-        spectrum_line["flux"],
-        spectrum_line["stdev"],
+        spectrum_line["flux_rest"],
+        spectrum_line["stdev_rest"],
         selected_lines["wavelength"],
         center_constraint,
         verbose,

--- a/gleam/plot_gaussian.py
+++ b/gleam/plot_gaussian.py
@@ -163,9 +163,9 @@ def plot_spectrum(
     ax = fig.add_subplot(111)
 
     # Overplot the observed spectrum
-    ax.plot(spectrum["wl_rest"], spectrum["flux"], color="gray")
+    ax.plot(spectrum["wl_rest"], spectrum["flux_rest"], color="gray")
     # Overplot the observed spectrum around the emission line in a bold colour
-    ax.plot(spectrum_line["wl_rest"], spectrum_line["flux"], color="black")
+    ax.plot(spectrum_line["wl_rest"], spectrum_line["flux_rest"], color="black")
 
     # plot zoom in on the fitted line
     sub_axes = inset_axes(
@@ -181,12 +181,12 @@ def plot_spectrum(
     select = (spectrum["wl_rest"] < (np.average(fitted_wl) + cont_width)) & (
         spectrum["wl_rest"] > (np.average(fitted_wl) - cont_width)
     )
-    sub_axes.plot(spectrum["wl_rest"][select], spectrum["flux"][select], color="gray")
+    sub_axes.plot(spectrum["wl_rest"][select], spectrum["flux_rest"][select], color="gray")
     ax.set_xlim(
         min(spectrum["wl_rest"]) - cont_width, max(spectrum["wl_rest"]) + cont_width
     )
     ylims = list(ax.get_ylim())
-    ylims[0] = max(ylims[0], -2 * np.std(spectrum["flux"].value))
+    ylims[0] = max(ylims[0], -2 * np.std(spectrum["flux_rest"].value))
     ax.set_ylim(ylims)
     sub_axes.set_xlim(sub_axes.get_xlim())
     sub_axes.set_ylim(sub_axes.get_ylim())
@@ -293,14 +293,14 @@ def overview_plot(
     ax = fig.add_subplot(311)
 
     # Plot the base restframe spectrum to the main axis
-    ax.plot(spectrum["wl_rest"], spectrum["flux"], color="k")
+    ax.plot(spectrum["wl_rest"], spectrum["flux_rest"], color="k")
 
     # Set x & y axis limits based on the spectrum
     ax.set_xlim(
         min(spectrum["wl_rest"]) - cont_width, max(spectrum["wl_rest"]) + cont_width
     )
     ylims = list(ax.get_ylim())
-    ylims[0] = max(ylims[0], -2 * np.std(spectrum["flux"].value))
+    ylims[0] = max(ylims[0], -2 * np.std(spectrum["flux_rest"].value))
     ax.set_ylim(ylims)
 
     j = 0
@@ -338,7 +338,7 @@ def overview_plot(
         if j > 0:
             axins.yaxis.label.set_visible(False)
         # Plot the observed spectrum in the zoomed-in axis
-        axins.plot(spectrum["wl_rest"][select], spectrum["flux"][select], color="k")
+        axins.plot(spectrum["wl_rest"][select], spectrum["flux_rest"][select], color="k")
 
         # Overplot the gaussian fit to the line in the zoomed-in axis
         plot_gaussian_fit(

--- a/gleam/spectra_operations.py
+++ b/gleam/spectra_operations.py
@@ -202,6 +202,20 @@ def restframe_wl(x, z):
     return x / (1.0 + z)
 
 
+def restframe_flux(x, z):
+    """
+    Transform a given spectrum flux density x into the restframe, given the 
+    redshift
+    Input:
+        x: observed flux density or standard deviation of a spectrum, in 
+        erg/s/cm^2/A for example
+        z: redshift
+    Return:
+        restframe spectrum flux density 
+    """
+    return x * (1.0 + z)
+
+
 def add_restframe(spectrum, z):
     """
     Add column with restframe spectrum onto the 1d spectrum flux
@@ -212,6 +226,9 @@ def add_restframe(spectrum, z):
         spectrum with the new added restframe wavelength column
     """
     spectrum.add_column(restframe_wl(spectrum["wl"], z), name="wl_rest")
+    spectrum.add_column(restframe_flux(spectrum["flux"],z), name="flux_rest")
+    spectrum.add_column(restframe_flux(spectrum["stdev"],z), name="stdev_rest")
+    
     return spectrum
 
 
@@ -257,7 +274,7 @@ def select_lines(
     """
     z_ref = target_info["Redshift"]
     wl_rest = spectrum["wl_rest"]
-    flux = spectrum["flux"]
+    flux = spectrum["flux_rest"]
     # Restframe resolution
     res_rest = dispersion(wl_rest)
     # mask all lines, but the line we are interested in


### PR DESCRIPTION
When restframing the spectrum, GLEAM did not properly correct the flux density (lambda) for the (1+z) factor, resulting in too small line fluxes. This pull request corrects this issue.